### PR TITLE
Add import/order and vue/valid-v-slot rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,5 +44,8 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'space-before-function-paren': 'off',
     'standard/no-callback-literal': 'off',
+    // Vuetify sometimes uses slot names with a "." (e.g. header.<name>). This
+    // prevents eslint from displaying an error for these slots
+    'vue/valid-v-slot': 'off',
   },
 }

--- a/index.js
+++ b/index.js
@@ -47,5 +47,19 @@ module.exports = {
     // Vuetify sometimes uses slot names with a "." (e.g. header.<name>). This
     // prevents eslint from displaying an error for these slots
     'vue/valid-v-slot': 'off',
+    // Define a common imports sort order
+    'import/order': [
+      'error',
+      {
+        alphabetize: { caseInsensitive: true, order: 'asc' },
+        groups: ['builtin', 'external', ['index', 'internal', 'parent', 'sibling']],
+        pathGroups: [
+          {
+            pattern: '@/**',
+            group: 'internal',
+          },
+        ],
+      },
+    ],
   },
 }


### PR DESCRIPTION
Add the following rules:

- vue/valid-v-slot: Tun this rule off for convenience so we don't get errors for vuetify slots that use a `.` in their name.
- import/order: Define this rule in our repository so we have direct control over it.