### PR TITLE
Disable camelcase rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,5 +61,6 @@ module.exports = {
         ],
       },
     ],
+    camelcase: 'off',
   },
 }


### PR DESCRIPTION
This PR disables the camel-case eslint rule:

https://eslint.org/docs/rules/camelcase

This rule enforces you to write property names and variables in camelCase. This is ok and we should continue this convention.

But it is an unnecessary restriction which just makes it more error prone when we just need to reuse properties from an object comming i.e. from the backend. Transforming the property names here is unnecessary and does not help reading or writing the code.

## Before
```js
const { name, filters, search, sort_on: sortOn, sort_order: sortOrder } = queryParams

const formData = { name }
if (search) formData.search = search
if (filters) formData.filters = filters
if (sortOn) formData.sort_on = sortOn
if (sortOrder) formData.sort_order = sortOrder

this.request(formData)
```

## After
```js
const { name, filters, search, sort_on, sort_order } = queryParams

const formData = { name }
if (search) formData.search = search
if (filters) formData.filters = filters
if (sort_on) formData.sort_on = sort_on
if (sort_order) formData.sort_order = sort_order

this.request(formData)
```